### PR TITLE
feat: add macos specific volume sync with objc core volume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,7 @@ dependencies = [
  "log",
  "oauth2",
  "objc",
+ "objc2-core-audio",
  "open",
  "raw-window-handle",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ url = "2.5"
 souvlaki = { version = "0.8.3", default-features = false }
 log = "0.4.33"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Already in the tree via cpal; the property calls are not feature-gated.
+objc2-core-audio = { version = "0.3", default-features = false }
+
 [build-dependencies]
 # librespot 0.8's build script is incompatible with vergen 9.1.
 vergen = "=9.0.6"

--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -74,7 +74,8 @@ impl Workspace {
                 | BackendEvent::PositionChanged { .. }
                 | BackendEvent::PlaybackSnapshotLoaded { .. }
                 | BackendEvent::PlaybackContext { .. }
-                | BackendEvent::PlaybackFailed(_) => {}
+                | BackendEvent::PlaybackFailed(_)
+                | BackendEvent::VolumeChanged(_) => {}
             }
         }
         cx.notify();

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -3,6 +3,12 @@ use super::*;
 /// How far playback may drift from the saved position before it is written back.
 const POSITION_SAVE_INTERVAL_MS: u32 = 5_000;
 
+/// On macOS the slider drives the system volume, so the backend pushes changes
+/// in via `VolumeChanged` instead of the app pushing its volume back out.
+fn volume_is_system_driven() -> bool {
+    cfg!(target_os = "macos")
+}
+
 /// Reported when a playback command could not be delivered to the backend.
 pub(super) struct PlaybackUnavailable;
 
@@ -306,7 +312,9 @@ impl Player {
         match event {
             BackendEvent::PlaybackReady => {
                 self.error = None;
-                self.backend.send(BackendCommand::SetVolume(self.volume));
+                if !volume_is_system_driven() {
+                    self.backend.send(BackendCommand::SetVolume(self.volume));
+                }
             }
             BackendEvent::PlaybackReconnecting => {
                 if self.restore.is_none() && self.now_playing.is_some() {
@@ -316,7 +324,9 @@ impl Player {
             }
             BackendEvent::PlaybackReconnected => {
                 self.error = None;
-                self.backend.send(BackendCommand::SetVolume(self.volume));
+                if !volume_is_system_driven() {
+                    self.backend.send(BackendCommand::SetVolume(self.volume));
+                }
                 if let Some((position_ms, playing)) = self.restore {
                     self.backend.send(BackendCommand::RestorePlayback {
                         position_ms,
@@ -425,6 +435,14 @@ impl Player {
                 }
                 cx.notify();
                 return Some(BackendEvent::TrackFailed { spotify_uri, error });
+            }
+            BackendEvent::VolumeChanged(volume) => {
+                if !self.volume_dragging {
+                    self.volume = volume;
+                    if volume > 0. {
+                        self.volume_before_mute = volume;
+                    }
+                }
             }
             event => return Some(event),
         }

--- a/src/app/test_support/interactions.rs
+++ b/src/app/test_support/interactions.rs
@@ -361,3 +361,50 @@ fn mute_sends_volume_and_restores_the_previous_level() {
     assert_eq!(*fixture.backend.volume.borrow_and_update(), initial);
     fixture.no_commands();
 }
+
+#[test]
+fn system_volume_changes_are_adopted_by_the_player() {
+    let mut fixture = Fixture::new(false);
+    fixture.update(|_, cx| {
+        services::AppServices::player(cx).update(cx, |player, cx| {
+            player.handle_backend_event(BackendEvent::VolumeChanged(0.35), cx);
+        })
+    });
+    fixture.update(|_, cx| assert_eq!(services::AppServices::player(cx).read(cx).volume(), 0.35));
+    fixture.update(|_, cx| {
+        services::AppServices::player(cx).update(cx, |player, cx| {
+            player.handle_backend_event(BackendEvent::VolumeChanged(0.6), cx);
+        })
+    });
+    fixture.update(|_, cx| assert_eq!(services::AppServices::player(cx).read(cx).volume(), 0.6));
+}
+
+#[test]
+fn system_volume_changes_are_ignored_while_dragging() {
+    let mut fixture = Fixture::new(false);
+    let dragged = fixture.update(|window, cx| {
+        services::AppServices::player(cx).update(cx, |player, cx| {
+            player.begin_volume_drag(px(1200.), window, cx);
+            player.volume()
+        })
+    });
+    fixture.update(|_, cx| {
+        services::AppServices::player(cx).update(cx, |player, cx| {
+            player.handle_backend_event(BackendEvent::VolumeChanged(0.1), cx);
+        })
+    });
+    fixture.update(|_, cx| {
+        let player = services::AppServices::player(cx).read(cx);
+        assert_eq!(player.volume(), dragged);
+        assert!(player.volume_dragging());
+    });
+    fixture.update(|_, cx| {
+        services::AppServices::player(cx).update(cx, |player, cx| player.end_volume_drag(cx))
+    });
+    fixture.update(|_, cx| {
+        services::AppServices::player(cx).update(cx, |player, cx| {
+            player.handle_backend_event(BackendEvent::VolumeChanged(0.1), cx);
+        })
+    });
+    fixture.update(|_, cx| assert_eq!(services::AppServices::player(cx).read(cx).volume(), 0.1));
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -20,6 +20,7 @@ use crate::{
         ClientIdSource, Spotify, SpotifyConfiguration, resolve_configuration, valid_client_id,
     },
     storage::{PlaybackSnapshot, Store},
+    system_volume,
 };
 
 const CATALOG_TIMEOUT_SECONDS: u64 = 30;
@@ -355,6 +356,7 @@ pub enum BackendEvent {
         playing: bool,
     },
     PlaybackSettled,
+    VolumeChanged(f32),
     QueueEnded,
     LibraryLoaded {
         generation: u64,
@@ -550,6 +552,13 @@ impl Backend {
         let (event_sender, events) = tokio::sync::mpsc::unbounded_channel();
         let (volume, volume_receiver) = tokio::sync::watch::channel(0.72);
         let (shutdown, shutdown_receiver) = tokio::sync::watch::channel(false);
+        system_volume::set_event_sink({
+            let events = event_sender.clone();
+            Box::new(move |volume| {
+                let _ = events.send(BackendEvent::VolumeChanged(volume));
+            })
+        });
+        system_volume::start_watcher();
         let thread = thread::Builder::new()
             .name("cadence-backend".to_owned())
             .spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ mod oauth_page;
 pub mod playback;
 pub mod spotify;
 pub mod storage;
+mod system_volume;
 
 pub use app::run;

--- a/src/playback.rs
+++ b/src/playback.rs
@@ -2,12 +2,17 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use anyhow::{Context as _, Result, anyhow};
 use keyring::Entry;
+#[cfg(not(target_os = "macos"))]
+use librespot::playback::{
+    config::VolumeCtrl,
+    mixer::{Mixer, MixerConfig},
+};
 use librespot::{
     core::{SpotifyUri, authentication::Credentials, config::SessionConfig, session::Session},
     oauth::OAuthClientBuilder,
     playback::{
-        config::{AudioFormat, PlayerConfig, VolumeCtrl},
-        mixer::{self, Mixer, MixerConfig},
+        config::{AudioFormat, PlayerConfig},
+        mixer::{self, VolumeGetter},
         player::{Player, PlayerEventChannel},
     },
 };
@@ -97,8 +102,9 @@ struct PlaybackOAuthToken {
 #[derive(Clone)]
 pub struct Playback {
     player: Arc<Player>,
-    mixer: Arc<dyn Mixer>,
     session: Session,
+    #[cfg(not(target_os = "macos"))]
+    mixer: Arc<dyn Mixer>,
 }
 
 impl Playback {
@@ -216,21 +222,27 @@ impl Playback {
             .connect(Credentials::with_access_token(access_token), false)
             .await
             .context("librespot could not connect to Spotify")?;
-        let mixer = mixer::find(None).context("no supported audio mixer is available")?(
-            MixerConfig::default(),
-        )?;
-        let volume = mixer.get_soft_volume();
+        #[cfg(target_os = "macos")]
+        let volume_getter: Box<dyn VolumeGetter + Send> = Box::new(mixer::NoOpVolume);
+        #[cfg(not(target_os = "macos"))]
+        let (volume_getter, soft_mixer) = {
+            let mixer = mixer::find(None).context("no supported audio mixer is available")?(
+                MixerConfig::default(),
+            )?;
+            (mixer.get_soft_volume(), mixer)
+        };
         let player_config = PlayerConfig {
             position_update_interval: Some(Duration::from_millis(250)),
             ..PlayerConfig::default()
         };
-        let player = Player::new(player_config, session.clone(), volume, move || {
+        let player = Player::new(player_config, session.clone(), volume_getter, move || {
             audio_output::open(None, AudioFormat::F32)
         });
         Ok(Self {
             player,
-            mixer,
             session,
+            #[cfg(not(target_os = "macos"))]
+            mixer: soft_mixer,
         })
     }
 
@@ -251,8 +263,14 @@ impl Playback {
     }
 
     pub fn set_volume(&self, volume: f32) {
+        let volume = volume.clamp(0., 1.);
+        #[cfg(target_os = "macos")]
+        {
+            crate::system_volume::set_output_volume(volume);
+        }
+        #[cfg(not(target_os = "macos"))]
         self.mixer
-            .set_volume((volume.clamp(0., 1.) * f32::from(VolumeCtrl::MAX_VOLUME)) as u16);
+            .set_volume((volume * f32::from(VolumeCtrl::MAX_VOLUME)) as u16);
     }
 
     pub fn stop(&self) {

--- a/src/system_volume.rs
+++ b/src/system_volume.rs
@@ -1,0 +1,120 @@
+//! Reads, writes, and watches the system output volume.
+
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+/// The volume as the operating system reports it, in 0..1, or `None` when the
+/// system output has no volume control.
+pub(crate) fn output_volume() -> Option<f32> {
+    macos::output_volume()
+}
+
+/// Sets the system output volume, reporting whether anything changed.
+pub(crate) fn set_output_volume(volume: f32) -> bool {
+    macos::set_output_volume(volume)
+}
+
+/// Where the watcher reports volume changes. Refreshed by every backend
+/// worker spawn so events reach the receiver the app is currently reading.
+pub(crate) fn set_event_sink(sink: VolumeEventSink) {
+    store_sink(sink);
+}
+
+/// Starts the background watcher that reports external volume changes.
+pub(crate) fn start_watcher() {
+    #[cfg(target_os = "macos")]
+    spawn_watcher();
+}
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(not(target_os = "macos"))]
+mod macos {
+    pub(super) fn output_volume() -> Option<f32> {
+        None
+    }
+
+    pub(super) fn set_output_volume(_volume: f32) -> bool {
+        false
+    }
+}
+
+type VolumeEventSink = Box<dyn Fn(f32) + Send + Sync>;
+
+static EVENT_SINK: Mutex<Option<VolumeEventSink>> = Mutex::new(None);
+static WATCHER_STARTED: AtomicBool = AtomicBool::new(false);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+const VOLUME_EPSILON: f32 = 0.001;
+
+fn store_sink(sink: VolumeEventSink) {
+    *EVENT_SINK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(sink);
+}
+
+fn publish(volume: f32) {
+    if let Some(sink) = EVENT_SINK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+    {
+        sink(volume);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_watcher() {
+    if WATCHER_STARTED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let spawned = thread::Builder::new()
+        .name("cadence-volume-watcher".to_owned())
+        .spawn(|| {
+            let mut last = None;
+            loop {
+                if let Some(volume) = output_volume()
+                    && last.is_none_or(|previous| differs_enough(previous, volume))
+                {
+                    publish(volume);
+                    last = Some(volume);
+                }
+                thread::sleep(POLL_INTERVAL);
+            }
+        });
+    if let Err(error) = spawned {
+        log::warn!("could not start the system volume watcher: {error}");
+    }
+}
+
+fn differs_enough(previous: f32, current: f32) -> bool {
+    (previous - current).abs() > VOLUME_EPSILON
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{differs_enough, output_volume};
+
+    #[test]
+    fn sub_epsilon_volume_moves_are_ignored() {
+        assert!(!differs_enough(0.5, 0.500_1));
+        assert!(differs_enough(0.5, 0.502));
+        assert!(differs_enough(0.5, 0.));
+    }
+
+    /// Read-only: tests must never change the system volume.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn system_output_volume_is_within_the_slider_range() {
+        if let Some(volume) = output_volume() {
+            assert!((0. ..=1.).contains(&volume));
+        }
+    }
+}

--- a/src/system_volume/macos.rs
+++ b/src/system_volume/macos.rs
@@ -1,0 +1,182 @@
+use std::{
+    mem::{MaybeUninit, size_of},
+    ptr::{NonNull, null},
+};
+
+use objc2_core_audio::{
+    AudioObjectGetPropertyData, AudioObjectID, AudioObjectIsPropertySettable,
+    AudioObjectPropertyAddress, AudioObjectPropertyElement, AudioObjectPropertyScope,
+    AudioObjectPropertySelector, AudioObjectSetPropertyData, kAudioDevicePropertyMute,
+    kAudioDevicePropertyVolumeScalar, kAudioHardwarePropertyDefaultOutputDevice,
+    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
+};
+
+type OSStatus = i32;
+
+const NO_ERROR: OSStatus = 0;
+const SYSTEM_OBJECT: AudioObjectID = kAudioObjectSystemObject as AudioObjectID;
+/// Probing bound for per-channel volume elements when a device reports more
+/// channels than any consumer setup the slider targets.
+const MAX_PROBED_ELEMENTS: AudioObjectPropertyElement = 8;
+
+pub(super) fn output_volume() -> Option<f32> {
+    let device = default_output_device()?;
+    if device_is_muted(device) {
+        return Some(0.);
+    }
+    let addresses = settable_volume_addresses(device);
+    let values = addresses
+        .iter()
+        .filter_map(|address| unsafe { get_property::<f32>(device, address) })
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return None;
+    }
+    let average = values.iter().sum::<f32>() / values.len() as f32;
+    Some(average.clamp(0., 1.))
+}
+
+pub(super) fn set_output_volume(volume: f32) -> bool {
+    let volume = volume.clamp(0., 1.);
+    let Some(device) = default_output_device() else {
+        return false;
+    };
+    let mut changed = false;
+    for address in settable_volume_addresses(device) {
+        changed |= unsafe { set_property(device, &address, &volume) };
+    }
+    if volume > 0. {
+        clear_mute(device);
+    }
+    changed
+}
+
+fn default_output_device() -> Option<AudioObjectID> {
+    let device = unsafe {
+        get_property::<AudioObjectID>(
+            SYSTEM_OBJECT,
+            &property_address(
+                kAudioHardwarePropertyDefaultOutputDevice,
+                kAudioObjectPropertyScopeGlobal,
+                MAIN_ELEMENT,
+            ),
+        )
+    }?;
+    (device != 0).then_some(device)
+}
+
+fn device_is_muted(device: AudioObjectID) -> bool {
+    matches!(
+        unsafe {
+            get_property::<u32>(
+                device,
+                &property_address(
+                    kAudioDevicePropertyMute,
+                    kAudioObjectPropertyScopeGlobal,
+                    MAIN_ELEMENT,
+                ),
+            )
+        },
+        Some(1)
+    )
+}
+
+/// Devices expose volume either on a master element or per output channel,
+/// never both, so both shapes are probed and the settable ones kept.
+fn settable_volume_addresses(device: AudioObjectID) -> Vec<AudioObjectPropertyAddress> {
+    probe_addresses()
+        .into_iter()
+        .filter(|address| property_is_settable(device, address))
+        .collect()
+}
+
+/// Every address that may carry an output volume: the master element plus the
+/// per-channel output elements.
+fn probe_addresses() -> Vec<AudioObjectPropertyAddress> {
+    let mut addresses = vec![property_address(
+        kAudioDevicePropertyVolumeScalar,
+        kAudioObjectPropertyScopeGlobal,
+        MAIN_ELEMENT,
+    )];
+    addresses.extend((1..=MAX_PROBED_ELEMENTS).map(|element| {
+        property_address(
+            kAudioDevicePropertyVolumeScalar,
+            kAudioObjectPropertyScopeOutput,
+            element,
+        )
+    }));
+    addresses
+}
+
+const MAIN_ELEMENT: AudioObjectPropertyElement = 0;
+
+fn property_address(
+    selector: AudioObjectPropertySelector,
+    scope: AudioObjectPropertyScope,
+    element: AudioObjectPropertyElement,
+) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress {
+        mSelector: selector,
+        mScope: scope,
+        mElement: element,
+    }
+}
+
+fn property_is_settable(device: AudioObjectID, address: &AudioObjectPropertyAddress) -> bool {
+    let mut settable: u8 = 0;
+    let status = unsafe {
+        AudioObjectIsPropertySettable(device, NonNull::from(address), NonNull::from(&mut settable))
+    };
+    status == NO_ERROR && settable != 0
+}
+
+/// Reads a property whose value is a fixed-size `Copy` type.
+unsafe fn get_property<T: Copy>(
+    object: AudioObjectID,
+    address: &AudioObjectPropertyAddress,
+) -> Option<T> {
+    let mut value = MaybeUninit::<T>::uninit();
+    let mut size = size_of::<T>() as u32;
+    let status = unsafe {
+        AudioObjectGetPropertyData(
+            object,
+            NonNull::from(address),
+            0,
+            null(),
+            NonNull::from(&mut size),
+            NonNull::from(&mut value).cast(),
+        )
+    };
+    (status == NO_ERROR).then(|| unsafe { value.assume_init() })
+}
+
+unsafe fn set_property<T>(
+    object: AudioObjectID,
+    address: &AudioObjectPropertyAddress,
+    value: &T,
+) -> bool {
+    unsafe {
+        AudioObjectSetPropertyData(
+            object,
+            NonNull::from(address),
+            0,
+            null(),
+            size_of::<T>() as u32,
+            NonNull::from(value).cast(),
+        ) == NO_ERROR
+    }
+}
+
+fn clear_mute(device: AudioObjectID) -> bool {
+    unsafe {
+        set_property(
+            device,
+            &property_address(
+                kAudioDevicePropertyMute,
+                kAudioObjectPropertyScopeGlobal,
+                MAIN_ELEMENT,
+            ),
+            &0_u32,
+        )
+    }
+}


### PR DESCRIPTION
Syncs the volume slider with the macos volume keys. 